### PR TITLE
安装模板时，提示命令无效

### DIFF
--- a/start/start-develop/get-ncf-template.md
+++ b/start/start-develop/get-ncf-template.md
@@ -7,6 +7,7 @@
 ```
 dotnet new install Senparc.NCF.Template
 ```
+> 如果你本地的.NET SDK版本大于6.0.100，那么就需要使用 `dotnet new --install Senparc.NCF.Template`命令安装即可。
 
 安装成功后，客户端提示：
 


### PR DESCRIPTION
修复：安装模板是提示命令无效
错误: 无效选项:
  Senparc.NCF.Template
有关使用情况信息，请运行: